### PR TITLE
Make REST endpoints compatible with Drupal core >= 8.5.0

### DIFF
--- a/modules/sku/src/Plugin/rest/resource/CategorySyncResource.php
+++ b/modules/sku/src/Plugin/rest/resource/CategorySyncResource.php
@@ -113,7 +113,7 @@ class CategorySyncResource extends ResourceBase {
    * @return \Drupal\rest\ResourceResponse
    *   HTTP Response.
    */
-  public function post(array $categories = []) {
+  public function post(array $categories) {
     $storeId = '';
     $requestHeaders = $this->currentRequest->headers;
     if ($requestHeaders->has('X-ACM-UUID')) {

--- a/modules/sku/src/Plugin/rest/resource/ProductStockSyncResource.php
+++ b/modules/sku/src/Plugin/rest/resource/ProductStockSyncResource.php
@@ -84,7 +84,7 @@ class ProductStockSyncResource extends ResourceBase {
    * @return \Drupal\rest\ResourceResponse
    *   HTTP Response object.
    */
-  public function post(array $stock = []) {
+  public function post(array $stock) {
     $storeId = '';
     $requestHeaders = $this->currentRequest->headers;
     if ($requestHeaders->has('X-ACM-UUID')) {

--- a/modules/sku/src/Plugin/rest/resource/ProductSyncResource.php
+++ b/modules/sku/src/Plugin/rest/resource/ProductSyncResource.php
@@ -91,7 +91,7 @@ class ProductSyncResource extends ResourceBase {
    * @return \Drupal\rest\ResourceResponse
    *   HTTP Response object.
    */
-  public function post(array $products = []) {
+  public function post(array $products) {
     $storeId = '';
     $requestHeaders = $this->currentRequest->headers;
     if ($requestHeaders->has('X-ACM-UUID')) {


### PR DESCRIPTION
In [CR](https://www.drupal.org/node/2894819) it was suggested that default parameter values are no longer replaced in Drupal core 8.5 and later. This is a probable cause of our issues with async synchronisation.