### PR TITLE
Update ACMAddressFormatter with new version of address class.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "commerceguys/intl": "~0.7",
-        "drupal/address": "~1.0",
+        "drupal/address": "^1.4.0",
         "drupal/field_group": "^1.0@RC",
         "drupal/key_value_field": "~1.0",
         "acquia/http-hmac-php": "~3.2",

--- a/src/ACMAddressFormatter.php
+++ b/src/ACMAddressFormatter.php
@@ -3,7 +3,7 @@
 namespace Drupal\acm;
 
 use CommerceGuys\Addressing\AddressFormat\AddressFormat;
-use CommerceGuys\Addressing\LocaleHelper;
+use CommerceGuys\Addressing\Locale;
 use Drupal\address\FieldHelper;
 use Drupal\Component\Utility\Html;
 use Drupal\Core\Render\Element;
@@ -148,7 +148,7 @@ class ACMAddressFormatter {
       // Remember the original value so that it can be used for $parents.
       $original_values[$field] = $values[$field];
       // Replace the value with the expected code.
-      $use_local_name = LocaleHelper::match('en', $subdivision->getLocale());
+      $use_local_name = Locale::match('en', $subdivision->getLocale());
       $values[$field] = $use_local_name ? $subdivision->getLocalCode() : $subdivision->getCode();
       if (!$subdivision->hasChildren()) {
         // The current subdivision has no children, stop.
@@ -182,7 +182,7 @@ class ACMAddressFormatter {
     $locale = $element['locale']['#value'];
     // Add the country to the bottom or the top of the format string,
     // depending on whether the format is minor-to-major or major-to-minor.
-    if (LocaleHelper::match($address_format->getLocale(), $locale)) {
+    if (Locale::match($address_format->getLocale(), $locale)) {
       $format_string = '%country' . "\n" . $address_format->getLocalFormat();
     }
     else {


### PR DESCRIPTION
LocaleHelper was renamed to Locale.

https://github.com/commerceguys/addressing/blob/53a6240b93a0e603efc149c6d2d4fa20eb72b726/src/LocaleHelper.php

to 

https://github.com/commerceguys/addressing/blob/b5c183725491dd34ee56257d28ee63ee241fc332/src/Locale.php

in this commit:
https://github.com/commerceguys/addressing/commit/b5c183725491dd34ee56257d28ee63ee241fc332#diff-d84d87b8395e3d11569331a5c51d41de