### PR TITLE
Reset keys for cart items to have properly indexed array.

### DIFF
--- a/src/APIHelper.php
+++ b/src/APIHelper.php
@@ -179,6 +179,12 @@ class APIHelper {
       unset($cart->response_message);
     }
 
+    // When we remove an item from cart, we have to reset the keys to have
+    // proper indexed array.
+    if (isset($cart->items)) {
+      $cart->items = array_values($cart->items);
+    }
+
     return $cart;
   }
 


### PR DESCRIPTION
When removing first item from cart, we unset it in $cart->items. This makes the array look like associative to GO. I get the following error:

Request (some values changed to generic values like name/id)
```{"cart_id":"111","store_id":"1","items":{"1":{"item_id":1,"sku":"1","qty":1,"name":"Name","price":0.5,"price_with_tax":0.5,"price_without_tax":0.47999999999999998,"product_type":"configurable","quote_id":"1","discount_amount":0,"discount_percent":0}},"coupon":"","cart_rules":[],"extension":{"attempted_payment":0,"shipping_method":""},"carrier":{"carrier_code":"","carrier_title":"","method_code":"","method_title":"","estimated":false,"amount":0,"amount_with_tax":0,"extension":{}}}```

Response:
```{"code":78,"message":"The cart information provided is invalid: code=400, message=Unmarshal type error: expected=[]types.CartItem, got=object, offset=42"}```