### PR TITLE
Queue operations from Drupal.

### DIFF
--- a/acm.install
+++ b/acm.install
@@ -5,6 +5,7 @@
  * Contains install hooks for acm.
  */
 
+use Drupal\Core\Url;
 use Drupal\user\Entity\Role;
 use Symfony\Component\Yaml\Yaml;
 
@@ -20,6 +21,30 @@ function acm_install() {
   catch (\Exception $e) {
     \Drupal::logger('acm')->info('ACM role already exists');
   }
+}
+
+/**
+ * Implements hook_requirements().
+ */
+function acm_requirements($phase) {
+  $requirements = [];
+
+  if ($phase != 'runtime') {
+    return $requirements;
+  }
+
+  $link_generator = \Drupal::service('link_generator');
+  $internal_url = Url::fromRoute('acm.configuration.purge_queue');
+  $internal_link = $link_generator->generate('here', $internal_url);
+
+  $requirements[] = [
+    'title' => t('Acquia Commerce Manager: Queue status'),
+    'value' => t('@countItems items', ['@countItems' => \Drupal::service('acm.api')->getQueueStatus()]),
+    'description' => t("This number represents number of items in Commerce Connector Service Queue. It doesn't show number of items which are currently being processed. You can purge queue @here.",
+      ['@here' => $internal_link]),
+  ];
+
+  return $requirements;
 }
 
 /**

--- a/acm.routing.yml
+++ b/acm.routing.yml
@@ -47,5 +47,14 @@ acm.configuration.commerce_users:
   requirements:
     _permission: 'access commerce administration pages'
 
+acm.configuration.purge_queue:
+  path: '/admin/commerce/config/purge-queue'
+  defaults:
+    _form: '\Drupal\acm\Form\PurgeQueueForm'
+    _title: 'Purge Queue'
+    _description: 'Perform purging of site queue.'
+  requirements:
+    _version_access_check: 'TRUE'
+
 route_callbacks:
   - 'acm.route_subscriber:routes'

--- a/acm.services.yml
+++ b/acm.services.yml
@@ -100,6 +100,12 @@ services:
     factory: cache_factory:get
     arguments: [commerce_user]
 
+  acm.version_access_checker:
+    class: Drupal\acm\Access\VersionAccessCheck
+    arguments: ['@current_user', '@config.factory']
+    tags:
+      - { name: access_check, applies_to: _version_access_check }
+
   repository.currency:
     class: CommerceGuys\Intl\Currency\CurrencyRepository
 

--- a/src/Access/VersionAccessCheck.php
+++ b/src/Access/VersionAccessCheck.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Drupal\acm\Access;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Routing\Access\AccessInterface;
+
+/**
+ * Checks access for displaying commerce admin pages with v2 specific functions.
+ */
+class VersionAccessCheck implements AccessInterface {
+
+  /**
+   * Config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Run access checks for this account.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $account;
+
+  /**
+   * Constructs a new VersionAccessCheck object.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   Run access checks for this account.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   */
+  public function __construct(AccountInterface $account, ConfigFactoryInterface $config_factory) {
+    $this->account = $account;
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * Check if v2 is set up and user can access commerce admin pages.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access() {
+    $version = $this->configFactory->get('acm.connector')->get('api_version');
+    if (($version === 'v2') && ($this->account->hasPermission('access commerce administration pages'))) {
+      return AccessResult::allowed();
+    }
+    return AccessResult::forbidden();
+  }
+
+}

--- a/src/Connector/APIWrapper.php
+++ b/src/Connector/APIWrapper.php
@@ -1014,4 +1014,54 @@ class APIWrapper implements APIWrapperInterface {
     return $result;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getQueueStatus(): int {
+    if ($this->apiVersion != 'v2') {
+      $this->logger->error('This feature is available only for v2. Current version is @version', ['@version' => $this->apiVersion]);
+      return -1;
+    }
+
+    $endpoint = $this->apiVersion . "/agent/queue/total";
+
+    $doReq = function ($client, $opt) use ($endpoint) {
+      return ($client->get($endpoint, $opt));
+    };
+
+    try {
+      $result = $this->tryAgentRequest($doReq, 'getQueueStatus');
+    }
+    catch (ConnectorException $e) {
+      throw new \Exception($e->getMessage(), $e->getCode());
+    }
+
+    return (int) $result['total'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function purgeQueue(): bool {
+    if ($this->apiVersion != 'v2') {
+      $this->logger->error('This feature is available only for v2.');
+      return FALSE;
+    }
+
+    $endpoint = $this->apiVersion . "/agent/queue/purge";
+
+    $doReq = function ($client, $opt) use ($endpoint) {
+      return ($client->post($endpoint, $opt));
+    };
+
+    try {
+      $this->tryAgentRequest($doReq, 'purgeQueue');
+    }
+    catch (ConnectorException $e) {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
 }

--- a/src/Connector/APIWrapperInterface.php
+++ b/src/Connector/APIWrapperInterface.php
@@ -448,4 +448,26 @@ interface APIWrapperInterface {
    */
   public function systemWatchdog();
 
+  /**
+   * Get number of items in site specific queue.
+   *
+   * @return int
+   *   Number of items in queue.
+   *
+   * @throws \Exception
+   *   Failed request exception.
+   */
+  public function getQueueStatus(): int;
+
+  /**
+   * Purge items in site specific queue.
+   *
+   * @return bool
+   *   Success of operation.
+   *
+   * @throws \Exception
+   *   Failed request exception.
+   */
+  public function purgeQueue(): bool;
+
 }

--- a/src/Connector/TestAPIWrapper.php
+++ b/src/Connector/TestAPIWrapper.php
@@ -328,4 +328,18 @@ class TestAPIWrapper extends APIWrapper {
    */
   public function updateStoreContext($store_id){}
 
+  /**
+   * {@inheritdoc}
+   */
+  public function getQueueStatus(): int {
+    return 5;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function purgeQueue(): bool {
+    return TRUE;
+  }
+
 }

--- a/src/Form/PurgeQueueForm.php
+++ b/src/Form/PurgeQueueForm.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Drupal\acm\Form;
+
+use Drupal\acm\Connector\APIWrapperInterface;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class PurgeQueueForm.
+ *
+ * @package Drupal\acm\Form
+ *
+ * @ingroup acm
+ */
+class PurgeQueueForm extends FormBase {
+
+  /**
+   * Connector Agent API Helper.
+   *
+   * @var \Drupal\acm\Connector\APIWrapperInterface
+   */
+  private $api;
+
+  /**
+   * PurgeQueueForm constructor.
+   *
+   * @param \Drupal\acm\Connector\APIWrapperInterface $api
+   *   APIWrapper object.
+   */
+  public function __construct(APIWrapperInterface $api) {
+    $this->api = $api;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('acm.api')
+    );
+  }
+
+  /**
+   * Returns a unique string identifying the form.
+   *
+   * @return string
+   *   The unique string identifying the form.
+   */
+  public function getFormId() {
+    return 'acm_purge_queue';
+  }
+
+  /**
+   * Define the form used for settings.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   An associative array containing the current state of the form.
+   *
+   * @return array
+   *   Form definition array.
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['actions']['#type'] = 'actions';
+
+    $form['actions']['purge_queue'] = [
+      '#type' => 'submit',
+      '#value' => t('Purge queue'),
+    ];
+
+    return ($form);
+  }
+
+  /**
+   * Form submission handler.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   An associative array containing the current state of the form.
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    try {
+      $this->api->purgeQueue();
+      $this->messenger()->addStatus($this->t('Queue was purged'));
+    }
+    catch (\Exception $e) {
+      $this->messenger()->addError($e->getMessage());
+    }
+  }
+
+}

--- a/tests/src/Unit/VersionAccessCheckTest.php
+++ b/tests/src/Unit/VersionAccessCheckTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Drupal\Tests\acm\Unit;
+
+use Drupal\acm\Access\VersionAccessCheck;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * @coversDefaultClass \Drupal\acm\Access\VersionAccessCheck
+ * @group acm
+ */
+class VersionAccessCheckTest extends UnitTestCase {
+
+  /**
+   * Tests passing case.
+   *
+   * @covers ::access
+   */
+  public function testExpectPass() {
+    $account = $this->prophesize(AccountInterface::class);
+    $account->hasPermission('access commerce administration pages')
+      ->willReturn(TRUE);
+
+    $configFactory = $this->getConfigFactoryStub([
+      'acm.connector' => [
+        'api_version' => 'v2',
+      ],
+    ]);
+
+    $checker = new VersionAccessCheck($account->reveal(), $configFactory);
+    $checkAccess = $checker->access();
+
+    $this->assertEquals($checkAccess, AccessResult::allowed());
+  }
+
+  /**
+   * Tests fails due to incorrect version.
+   *
+   * @covers ::access
+   */
+  public function testFailBecauseVersion() {
+    $account = $this->prophesize(AccountInterface::class);
+    $account->hasPermission('access commerce administration pages')
+      ->willReturn(TRUE);
+
+    $configFactory = $this->getConfigFactoryStub([
+      'acm.connector' => [
+        'api_version' => 'v1',
+      ],
+    ]);
+
+    $checker = new VersionAccessCheck($account->reveal(), $configFactory);
+    $checkAccess = $checker->access();
+
+    $this->assertEquals($checkAccess, AccessResult::forbidden());
+  }
+
+  /**
+   * Tests fail due to missing permissions.
+   *
+   * @covers ::access
+   */
+  public function testFailBecausePermissions() {
+    $account = $this->prophesize(AccountInterface::class);
+    $account->hasPermission('access commerce administration pages')
+      ->willReturn(FALSE);
+
+    $configFactory = $this->getConfigFactoryStub([
+      'acm.connector' => [
+        'api_version' => 'v2',
+      ],
+    ]);
+
+    $checker = new VersionAccessCheck($account->reveal(), $configFactory);
+    $checkAccess = $checker->access();
+
+    $this->assertEquals($checkAccess, AccessResult::forbidden());
+  }
+
+  /**
+   * Tests fail due to missing permissions and incorrect version.
+   *
+   * @covers ::access
+   */
+  public function testCompleteFail() {
+    $account = $this->prophesize(AccountInterface::class);
+    $account->hasPermission('access commerce administration pages')
+      ->willReturn(FALSE);
+
+    $configFactory = $this->getConfigFactoryStub([
+      'acm.connector' => [
+        'api_version' => 'v1',
+      ],
+    ]);
+
+    $checker = new VersionAccessCheck($account->reveal(), $configFactory);
+    $checkAccess = $checker->access();
+
+    $this->assertEquals($checkAccess, AccessResult::forbidden());
+  }
+
+}


### PR DESCRIPTION
This PR enables users with v2 middleware to perform queue operations - get status and purge queue. It also introduces new access check, which can be used for pages which require v2 and admin access to commerce admin pages.