### PR TITLE
Avoid 500 issues with ResourceResponse related to leaked metadata.

### DIFF
--- a/modules/customer/src/Plugin/rest/resource/CustomerDeleteResource.php
+++ b/modules/customer/src/Plugin/rest/resource/CustomerDeleteResource.php
@@ -3,7 +3,7 @@
 namespace Drupal\acm_customer\Plugin\rest\resource;
 
 use Drupal\Core\Entity\EntityStorageException;
-use Drupal\rest\ResourceResponse;
+use Drupal\rest\ModifiedResourceResponse;
 use Drupal\rest\Plugin\ResourceBase;
 
 /**
@@ -32,7 +32,7 @@ class CustomerDeleteResource extends ResourceBase {
    * @param array $data
    *   Post data.
    *
-   * @return \Drupal\rest\ResourceResponse
+   * @return \Drupal\rest\ModifiedResourceResponse
    *   HTTP Response.
    */
   public function post(array $data = []) {
@@ -40,7 +40,7 @@ class CustomerDeleteResource extends ResourceBase {
     if (!$data['email']) {
       $this->logger->error('Invalid data to delete customer.');
       $response['success'] = (bool) (FALSE);
-      return (new ResourceResponse($response));
+      return (new ModifiedResourceResponse($response));
     }
 
     $email = $data['email'];
@@ -52,18 +52,18 @@ class CustomerDeleteResource extends ResourceBase {
         $user->delete();
         $this->logger->notice('Deleted user with uid %id and email %email.', ['%id' => $user->id(), '%email' => $email]);
         $response['success'] = (bool) (TRUE);
-        return (new ResourceResponse($response));
+        return (new ModifiedResourceResponse($response));
       }
       catch (EntityStorageException $e) {
         $this->logger->error($e->getMessage());
         $response['success'] = (bool) (FALSE);
-        return (new ResourceResponse($response));
+        return (new ModifiedResourceResponse($response));
       }
     }
     else {
       $this->logger->warning('User with email %email doesn\'t exist.', ['%email' => $email]);
       $response['success'] = (bool) (FALSE);
-      return (new ResourceResponse($response));
+      return (new ModifiedResourceResponse($response));
     }
   }
 

--- a/modules/customer/tests/src/Unit/CustomerDeleteResourceTest.php
+++ b/modules/customer/tests/src/Unit/CustomerDeleteResourceTest.php
@@ -38,7 +38,7 @@ class CustomerDeleteResourceTest extends UnitTestCase {
   /**
    * A response object.
    *
-   * @var \Drupal\rest\ResourceResponse
+   * @var \Drupal\rest\ModifiedResourceResponse
    */
   protected $response;
 

--- a/modules/sku/src/Plugin/rest/resource/CategorySyncResource.php
+++ b/modules/sku/src/Plugin/rest/resource/CategorySyncResource.php
@@ -5,7 +5,7 @@ namespace Drupal\acm_sku\Plugin\rest\resource;
 use Drupal\acm_sku\CategoryManagerInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\rest\Plugin\ResourceBase;
-use Drupal\rest\ResourceResponse;
+use Drupal\rest\ModifiedResourceResponse;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -110,7 +110,7 @@ class CategorySyncResource extends ResourceBase {
    * @param array $categories
    *   Category data for update.
    *
-   * @return \Drupal\rest\ResourceResponse
+   * @return \Drupal\rest\ModifiedResourceResponse
    *   HTTP Response.
    */
   public function post(array $categories) {
@@ -121,7 +121,7 @@ class CategorySyncResource extends ResourceBase {
     }
 
     if (!$this->categoryVid) {
-      return (new ResourceResponse(['success' => FALSE]));
+      return (new ModifiedResourceResponse(['success' => FALSE]));
     }
 
     $response = $this->categoryManager->synchronizeCategory(
@@ -132,7 +132,7 @@ class CategorySyncResource extends ResourceBase {
 
     $response['success'] = (bool) (($response['created'] > 0) || ($response['updated'] > 0));
 
-    return (new ResourceResponse($response));
+    return (new ModifiedResourceResponse($response));
   }
 
 }

--- a/modules/sku/src/Plugin/rest/resource/ProductStockSyncResource.php
+++ b/modules/sku/src/Plugin/rest/resource/ProductStockSyncResource.php
@@ -4,7 +4,7 @@ namespace Drupal\acm_sku\Plugin\rest\resource;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\rest\Plugin\ResourceBase;
-use Drupal\rest\ResourceResponse;
+use Drupal\rest\ModifiedResourceResponse;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -81,7 +81,7 @@ class ProductStockSyncResource extends ResourceBase {
    * @param array $stock
    *   Stock Data.
    *
-   * @return \Drupal\rest\ResourceResponse
+   * @return \Drupal\rest\ModifiedResourceResponse
    *   HTTP Response object.
    */
   public function post(array $stock) {
@@ -91,7 +91,7 @@ class ProductStockSyncResource extends ResourceBase {
       $storeId = $requestHeaders->get('X-ACM-UUID');
     }
     $response = $this->productManager->synchronizeStockData($stock, $storeId);
-    return (new ResourceResponse($response));
+    return (new ModifiedResourceResponse($response));
   }
 
 }

--- a/modules/sku/src/Plugin/rest/resource/ProductSyncResource.php
+++ b/modules/sku/src/Plugin/rest/resource/ProductSyncResource.php
@@ -4,7 +4,7 @@ namespace Drupal\acm_sku\Plugin\rest\resource;
 
 use Drupal\acm_sku\ProductManagerInterface;
 use Drupal\rest\Plugin\ResourceBase;
-use Drupal\rest\ResourceResponse;
+use Drupal\rest\ModifiedResourceResponse;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -88,7 +88,7 @@ class ProductSyncResource extends ResourceBase {
    * @param array $products
    *   Product / SKU Data.
    *
-   * @return \Drupal\rest\ResourceResponse
+   * @return \Drupal\rest\ModifiedResourceResponse
    *   HTTP Response object.
    */
   public function post(array $products) {
@@ -101,7 +101,7 @@ class ProductSyncResource extends ResourceBase {
     \Drupal::logger('acm_sku')->info("Updating products for acm_uuid " . $storeId . ".");
 
     $response = $this->productManager->synchronizeProducts($products, $storeId);
-    return (new ResourceResponse($response));
+    return (new ModifiedResourceResponse($response));
   }
 
 }


### PR DESCRIPTION
Exception:
```
/productsync?_format=json||6||LogicException: The controller result claims to be providing relevant cache metadata, but leaked metadata was detected. Please ensure you are not rendering content too early. Returned object class: Drupal\rest\ResourceResponse. in Drupal\Core\EventSubscriber\EarlyRenderingControllerWrapperSubscriber->wrapControllerExecutionInRenderContext() (line 154 of docroot/core/lib/Drupal/Core/EventSubscriber/EarlyRenderingControllerWrapperSubscriber.php).
```