### PR TITLE
Alias not created for the tranlsated node.

### DIFF
--- a/modules/sku/acm_sku.services.yml
+++ b/modules/sku/acm_sku.services.yml
@@ -50,6 +50,7 @@ services:
       - '@acm_sku.category_repo'
       - '@acm_sku.product_options_manager'
       - '@acm.i18n_helper'
+      - '@module_handler'
 
   cache.stock:
       class: Drupal\Core\Cache\CacheBackendInterface

--- a/modules/sku/src/ProductManager.php
+++ b/modules/sku/src/ProductManager.php
@@ -394,7 +394,10 @@ class ProductManager implements ProductManagerInterface {
           $this->updateNodeTranslation($node, $product, $langcode);
         }
 
-        // Alias for the product if path auto enabled.
+        // We doing this because when the translation of node is created by
+        // addTranslation(), pathauto alias is not created for the translated
+        // version.
+        // @see https://www.drupal.org/project/pathauto/issues/2995829.
         if (\Drupal::moduleHandler()->moduleExists('pathauto')) {
           $node->path->pathauto = 1;
         }

--- a/modules/sku/src/ProductManager.php
+++ b/modules/sku/src/ProductManager.php
@@ -393,6 +393,12 @@ class ProductManager implements ProductManagerInterface {
         elseif ($node->hasTranslationChanges()) {
           $this->updateNodeTranslation($node, $product, $langcode);
         }
+
+        // Alias for the product if path auto enabled.
+        if (\Drupal::moduleHandler()->moduleExists('pathauto')) {
+          $node->path->pathauto = 1;
+        }
+
         // Invoke the alter hook to allow all modules to update the node.
         \Drupal::moduleHandler()
           ->alter('acm_sku_product_node', $node, $product, $langcode);


### PR DESCRIPTION
So if path auto module is enabled, an alias is not created for the translated version node.

**Steps** -

- Should be a multilingual site (more than one or say two languages enabled).

- Enable path auto module

- Set the pattern for the product bundle.

`$data = [
    'title' => 'Test Product Arabic',
    'type' => 'acm_product',
    'langcode' => 'ar',
  ];
  $node = \Drupal::entityTypeManager()->getStorage('node')->create($data);
  $node->save();

  $node = \Drupal\node\Entity\Node::load($node->id());
  $node = $node->addTranslation('en');
  $node->get('title')->setValue('Test Product English');
  $node->save();`

Alias is not created for the English version of the node.

Looks like a core/pathauto specific issue (not sure if we fix here or there).

Reason is `if ($entity->path->pathauto != PathautoState::CREATE && empty($options['force'])) { return NULL; }` in `PathautoGenerator::updateEntityAlias()` where 

