### PR TITLE
Use Drupal httpClient to ensure server is not slowed down for invalid urls.

### DIFF
--- a/modules/sku/src/Entity/SKU.php
+++ b/modules/sku/src/Entity/SKU.php
@@ -10,6 +10,7 @@ use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\file\Entity\File;
 use Drupal\user\UserInterface;
+use GuzzleHttp\Exception\RequestException;
 
 /**
  * Defines the SKU entity.
@@ -678,10 +679,14 @@ class SKU extends ContentEntityBase implements SKUInterface {
     $args = ['@file' => $data['file'], '@sku_id' => $this->id()];
 
     // Download the file contents.
-    $file_data = file_get_contents($data['file']);
-
-    // Check to ensure errors like 404, 403, etc. are catched and empty file
-    // not saved in SKU.
+    $client = \Drupal::httpClient();
+    try {
+      $file_data = $client->get($data['file']);
+    }
+    catch (RequestException $e) {
+      watchdog_exception('acq_commerce', $e);
+    }
+    // Check to ensure empty file is not saved in SKU.
     if (empty($file_data)) {
       throw new \Exception(new FormattableMarkup('Failed to download file "@file" for SKU id @sku_id.', $args));
     }


### PR DESCRIPTION
We are using file_get_contents for downloading files. We can use \Drupal::httpClient() instead to download file and make it fast. This also sets a server timeout of 30seconds for invalid urls.