### PR TITLE
Adding check as array might be null due to langcode.

### DIFF
--- a/modules/sku/src/Entity/SKU.php
+++ b/modules/sku/src/Entity/SKU.php
@@ -144,6 +144,10 @@ class SKU extends ContentEntityBase implements SKUInterface {
 
     $sku_entity = array_shift($skus);
 
+    if (empty($sku_entity)) {
+      return NULL;
+    }
+
     if ($is_multilingual) {
       if ($sku_entity->hasTranslation($langcode)) {
         $sku_entity = $sku_entity->getTranslation($langcode);


### PR DESCRIPTION
**How to replicate** - 
1. If we have a SKU with default language as **EN** for example.
2. Now if we try to load the SKU by SKU::loadFromSku("my sku", "ar") where langcode is different other than the default/original SKU langcode.
3. So this 
```
$storage = \Drupal::entityTypeManager()->getStorage('acm_sku');
    $skus = $storage->loadByProperties(['sku' => $sku]);
```
Will load the SKU for **EN** (original/default) langcode
4. And due to this
```
foreach ($skus as $key => $sku) {
        if ($sku->langcode->value != $langcode) {
          unset($skus[$key]);
        }
      }
```
We uset/remove SKU as langcode is different.
5. And thus $sku_entity = array_shift($skus); will return empty
6. And thus 
```
if($sku_entity->hasTranslation($langcode)) {
        $sku_entity = $sku_entity->getTranslation($langcode);
      }
```
will throw error.