### PR TITLE
Fix for Notice: Array to string conversion notice.

### DIFF
--- a/modules/acm_sku/src/Plugin/AcquiaCommerce/SKUType/Configurable.php
+++ b/modules/acm_sku/src/Plugin/AcquiaCommerce/SKUType/Configurable.php
@@ -645,12 +645,19 @@ class Configurable extends SKUPluginBase {
       }
     }
 
-    // Create name from label parts.
-    $cartName = sprintf(
-      '%s (%s)',
-      $cart['name'],
-      implode(', ', $label_parts)
-    );
+    // If the cart name has already been constructed and is rendered as a link,
+    // use the title directly.
+    if (!empty($cart['name']['#title'])) {
+      $cartName = $cart['name']['#title'];
+    }
+    else {
+      // Create name from label parts.
+      $cartName = sprintf(
+        '%s (%s)',
+        $cart['name'],
+        implode(', ', $label_parts)
+      );
+    }
 
     if (!$asString) {
       $display_node = $this->getDisplayNode($parent_sku);


### PR DESCRIPTION
Fix for the 'Notice: Array to string conversion in Drupal\acq_sku\Plugin\AcquiaCommerce\SKUType\Configurable->cartName()' while adding products to cart.