### PR TITLE
Dispatch event in case not sku on cart submit.

### DIFF
--- a/modules/acm_sku/src/Plugin/AcquiaCommerce/SKUType/Configurable.php
+++ b/modules/acm_sku/src/Plugin/AcquiaCommerce/SKUType/Configurable.php
@@ -375,7 +375,7 @@ class Configurable extends SKUPluginBase {
     }
     else {
       $message = t('The current selection does not appear to be valid.');
-      drupal_set_message($message);
+      \Drupal::messenger($message);
       // Dispatch event so action can be taken.
       $dispatcher = \Drupal::service('event_dispatcher');
       $exception = new \Exception($message);

--- a/modules/acm_sku/src/Plugin/AcquiaCommerce/SKUType/Configurable.php
+++ b/modules/acm_sku/src/Plugin/AcquiaCommerce/SKUType/Configurable.php
@@ -374,7 +374,13 @@ class Configurable extends SKUPluginBase {
       }
     }
     else {
-      drupal_set_message(t('The current selection does not appear to be valid.'));
+      $message = t('The current selection does not appear to be valid.');
+      drupal_set_message($message);
+      // Dispatch event so action can be taken.
+      $dispatcher = \Drupal::service('event_dispatcher');
+      $exception = new \Exception($message);
+      $event = new AddToCartErrorEvent($exception);
+      $dispatcher->dispatch(AddToCartErrorEvent::SUBMIT, $event);
     }
   }
 


### PR DESCRIPTION
Issue is like this -

- Child SKU of a configurable product is disabled on Magento.

- This deletes the child SKU on the Drupal end.

- Now if a user is already on the cart page and just clicks the add to cart button (without page refresh), we get this error (as ajax in our system).

- As we have event dispatcher in place for error, I think we should also dispatch in this case as well.




cc @sdelbosc 