### PR TITLE
Fix "Fatal error: Declaration of Variant::processImport() must be compatible with interface..."

### DIFF
--- a/modules/acm_sku/src/Plugin/AcquiaCommerce/SKUType/Variant.php
+++ b/modules/acm_sku/src/Plugin/AcquiaCommerce/SKUType/Variant.php
@@ -5,6 +5,7 @@ namespace Drupal\acm_sku\Plugin\AcquiaCommerce\SKUType;
 use Drupal\acm_sku\AcquiaCommerce\SKUPluginBase;
 use Drupal\acm_sku\AddToCartErrorEvent;
 use Drupal\acm_sku\Entity\SKU;
+use Drupal\acm_sku\Entity\SKUInterface;
 use Drupal\acm_sku\Entity\SKUType;
 use Drupal\acm_sku\Entity\SKUTypeInterface;
 use Drupal\Core\Cache\Cache;
@@ -414,7 +415,7 @@ class Variant extends SKUPluginBase {
   /**
    * {@inheritdoc}
    */
-  public function processImport(SKU $configuredSkuEntity, array $product) {
+  public function processImport(SKUInterface $configuredSkuEntity, array $product) {
     $configuredSkuEntity->field_configurable_attributes->value =
       serialize($product['extension']['configurable_product_options']);
 


### PR DESCRIPTION
When interpreted, `modules/acm_sku/src/Plugin/AcquiaCommerce/SKUType/Variant.php` causes the following fatal error:

> Fatal error: Declaration of Drupal\acm_sku\Plugin\AcquiaCommerce\SKUType\Variant::processImport(Drupal\acm_sku\Entity\SKU $configuredSkuEntity, array $product) must be compatible with Drupal\acm_sku\AcquiaCommerce\SKUPluginInterface::processImport(Drupal\acm_sku\Entity\SKUInterface $sku, array $product) in /var/www/docroot/modules/contrib/acquia_commercemanager/modules/acm_sku/src/Plugin/AcquiaCommerce/SKUType/Variant.php on line 556

This PR fixes it.