### PR TITLE
Integrate ORCA test framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ cache:
     - "$HOME/.drush/cache"
     - "$TMPDIR/phpstan/cache"
 
+env:
+  global:
+    - "ORCA_PACKAGES_CONFIG_ALTER=../commerce-manager/packages.yml"
+
 matrix:
   fast_finish: true
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,58 +1,36 @@
+---
 language: php
+dist: trusty
 
-php:
-  - 7.1
-  - 7.2
+php: 7.1
 
-env:
-  - DRUPAL=~8.5.0
-  - DRUPAL=~8.6.0
-  - DRUPAL=8.5.x-dev
-  - DRUPAL=8.6.x-dev
+addons:
+  chrome: stable
 
-before_install:
-  # items for phpcs
-  - composer global require drupal/coder ^8.2@stable
-  - export COMPOSER_HOME=`composer config home`
-  - export PATH="$PATH:$COMPOSER_HOME/vendor/bin" 
-  - phpcs --config-set installed_paths $COMPOSER_HOME/vendor/drupal/coder/coder_sniffer
-  - phpcs --standard=Drupal .
+cache:
+  directories:
+    - "$HOME/.composer/cache"
+    - "$HOME/.drush/cache"
+    - "$TMPDIR/phpstan/cache"
+
+matrix:
+  fast_finish: true
+  include:
+    - { name: "Static code analysis", env: ORCA_JOB=STATIC_CODE_ANALYSIS }
+    - { name: "Deprecated code scan w/ SUT", env: ORCA_JOB=DEPRECATED_CODE_SCAN_SUT }
+    - { name: "Deprecated code scan w/ dependencies", env: ORCA_JOB=DEPRECATED_CODE_SCAN_CONTRIB }
+    - { name: "Isolated test w/ recommended package versions", env: ORCA_JOB=ISOLATED_RECOMMENDED }
+    - { name: "Integrated test w/ recommended package versions", env: ORCA_JOB=INTEGRATED_RECOMMENDED }
+    - { name: "Isolated test w/ dev package versions", env: ORCA_JOB=ISOLATED_DEV }
+    - { name: "Integrated test w/ dev package versions", env: ORCA_JOB=INTEGRATED_DEV }
+  allow_failures:
+    - env: ORCA_JOB=DEPRECATED_CODE_SCAN_SUT
+    - env: ORCA_JOB=DEPRECATED_CODE_SCAN_CONTRIB
+    - env: ORCA_JOB=ISOLATED_DEV
+    - env: ORCA_JOB=INTEGRATED_DEV
+
 install:
-# Create the MySQL database and add a user for testing.
-  - mysql -u root -e "CREATE DATABASE testing; CREATE USER 'testing'@'localhost' IDENTIFIED BY 'testing'; GRANT ALL ON testing.* TO 'testing'@'localhost';"
-  - export SIMPLETEST_DB="mysql://testing:testing@localhost/testing"
-  - export SIMPLETEST_BASE_URL=http://localhost:8080
-  # first clone everything also into a subfolder, via a parent build folder
-  - mkdir acm
-  - mv `ls -A | grep -v "^acm$"` ./acm
-  - composer clearcache
-  - composer self-update
-  - composer create-project drupal/drupal:${DRUPAL} drupal --no-interaction --no-install
-  # Add packages required by acm.
-  - cd drupal
-  # see https://github.com/drupal-composer/drupal-project/issues/175
-  - composer config --unset repositories.0
-  - composer config repositories.drupal composer https://packages.drupal.org/8
-  - mkdir -p modules/contrib
-  - mv ../acm modules/contrib
-  - composer require drush/drush commerceguys/intl:~0.7 drupal/address:~1.0 drupal/key_value_field:~1.0 drupal/field_group:^3.0@beta drupal/pcb:~1.0 acquia/http-hmac-php:~3.2.0 drupal/simple_oauth:'~3.8' drupal/consumers:'1.4' drupal/inline_entity_form php-coveralls/php-coveralls
-  - composer run-script drupal-phpunit-upgrade
-  - composer install
-  # Install drupal.
-  - ./vendor/bin/drush --verbose site-install --db-url=mysql://root:@127.0.0.1/drupal --yes
-  # Enable the acm suite of modules.
-  - ./vendor/bin/drush en -y acm acm_cart acm_checkout acm_customer acm_exception acm_payment acm_product acm_promotion acm_sku acm_sku_position
-  # Enable simpletest for module tests
-  - ./vendor/bin/drush en -y simpletest
-before_script:
-  - phpenv config-rm xdebug.ini
-  - mkdir -p $TRAVIS_BUILD_DIR/drupal/sites/simpletest && chmod 777 $TRAVIS_BUILD_DIR/drupal/sites/simpletest -fR
-  - cd $TRAVIS_BUILD_DIR/drupal
-  - ./vendor/bin/drush runserver localhost:8080 &
-  - echo $! > drush_runserver.pid
-  - until netstat -an 2>/dev/null | grep '8080.*LISTEN'; do true; done
-script:
-  - mkdir -p $TRAVIS_BUILD_DIR/drupal/modules/contrib/acm/tests/logs
-  # Run behat tests.
-  - ./vendor/bin/phpunit -c modules/contrib/acm/phpunit.xml modules/contrib/acm --debug -v --stop-on-failure
-  - kill -s TERM `cat drush_runserver.pid`
+  - "git clone --branch v1.0.0-alpha6 --depth 1 https://github.com/acquia/orca.git ../orca"
+  - "../orca/bin/travis/install 8.x-1.x"
+
+script: "../orca/bin/travis/script drupal/acquia_commercemanager"

--- a/behat.yml
+++ b/behat.yml
@@ -28,7 +28,7 @@ default:
       blackbox: ~
       api_driver: "drupal"
       drupal:
-        drupal_root: '/var/www/html'
+        drupal_root: 'docroot'
       region_map:
         content: "#content"
         body: "body"

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,11 @@
         "drupal/pcb": "~1.0",
         "drupal/simple_oauth": "^3"
     },
+    "extra": {
+        "branch-alias": {
+            "dev-8.x-1.x": "1.x-dev"
+        }
+    },
     "autoload": {
         "classmap": [
             "features/bootstrap/"

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,9 @@
 {
     "name": "drupal/acquia_commercemanager",
-    "description": "This project provides the ability to use the Acquia Commerce Connector.",
     "type": "drupal-module",
-    "license": "GPL-2.0+",
-    "minimum-stability": "dev",
+    "description": "This project provides the ability to use the Acquia Commerce Connector.",
     "homepage": "https://www.drupal.org/project/acquia_commercemanager",
+    "license": "GPL-2.0+",
     "authors": [
         {
             "name": "Acquia Engineering",
@@ -12,33 +11,34 @@
             "role": "Maintainer"
         }
     ],
-    "support": {
-        "issues": "https://github.com/acquia/commerce-manager/issues",
-        "source": "https://github.com/acquia/commerce-manager"
-    },
     "require": {
         "php": "^7.1",
+        "acquia/http-hmac-php": "~3.2",
         "commerceguys/intl": "~1.0",
         "drupal/address": "^1.4.0",
+        "drupal/consumers": "1.4",
         "drupal/field_group": "^3.0@beta",
         "drupal/inline_entity_form": "^1.0@rc",
         "drupal/key_value_field": "~1.0",
-        "acquia/http-hmac-php": "~3.2",
         "drupal/pcb": "~1.0",
-        "drupal/simple_oauth": "^3",
-        "drupal/consumers": "1.4"
+        "drupal/simple_oauth": "^3"
     },
     "require-dev": {
         "behat/behat": "3.5.*",
-        "behat/mink-goutte-driver": "*",
+        "behat/mink": "*",
         "behat/mink-browserkit-driver": "*",
         "behat/mink-extension": "*",
+        "behat/mink-goutte-driver": "*",
         "behat/mink-selenium2-driver": "*",
-        "behat/mink": "*",
-        "drupal/drupal-extension": "3.4.*",
         "drupal/drupal-driver": "*",
+        "drupal/drupal-extension": "3.4.*",
+        "emuse/behat-html-formatter": "^0.1.0",
         "jakoch/phantomjs-installer": "*",
-        "se/selenium-server-standalone": "3.4.0",
-        "emuse/behat-html-formatter": "^0.1.0"
+        "se/selenium-server-standalone": "3.4.0"
+    },
+    "minimum-stability": "dev",
+    "support": {
+        "issues": "https://github.com/acquia/commerce-manager/issues",
+        "source": "https://github.com/acquia/commerce-manager"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "drupal-module",
     "description": "This project provides the ability to use the Acquia Commerce Connector.",
     "homepage": "https://www.drupal.org/project/acquia_commercemanager",
-    "license": "GPL-2.0+",
+    "license": "GPL-2.0-or-later",
     "authors": [
         {
             "name": "Acquia Engineering",

--- a/composer.json
+++ b/composer.json
@@ -23,19 +23,6 @@
         "drupal/pcb": "~1.0",
         "drupal/simple_oauth": "^3"
     },
-    "require-dev": {
-        "behat/behat": "3.5.*",
-        "behat/mink": "*",
-        "behat/mink-browserkit-driver": "*",
-        "behat/mink-extension": "*",
-        "behat/mink-goutte-driver": "*",
-        "behat/mink-selenium2-driver": "*",
-        "drupal/drupal-driver": "*",
-        "drupal/drupal-extension": "3.4.*",
-        "emuse/behat-html-formatter": "^0.1.0",
-        "jakoch/phantomjs-installer": "*",
-        "se/selenium-server-standalone": "3.4.0"
-    },
     "minimum-stability": "dev",
     "support": {
         "issues": "https://github.com/acquia/commerce-manager/issues",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,11 @@
         "drupal/pcb": "~1.0",
         "drupal/simple_oauth": "^3"
     },
+    "autoload": {
+        "classmap": [
+            "features/bootstrap/"
+        ]
+    },
     "minimum-stability": "dev",
     "support": {
         "issues": "https://github.com/acquia/commerce-manager/issues",

--- a/features/cart.feature
+++ b/features/cart.feature
@@ -1,4 +1,4 @@
-@javascript
+@javascript @orca_ignore
 Feature: Test basket page
 
   Background:

--- a/features/checkout.feature
+++ b/features/checkout.feature
@@ -1,4 +1,4 @@
-@javascript
+@javascript @orca_ignore
 Feature: Test Checkout feature
   Background:
     Given I am an anonymous user
@@ -299,7 +299,7 @@ Feature: Test Checkout feature
     And I wait for the page to load
     Then I should see "Your order has been submitted" in the "content"
 
-  @shipping @justthisone
+  @shipping
   Scenario: As a Guest,
   I should be able to use same shipping address and then change it from review pane and checkout using COD.
     Given I enter a valid Email ID in field "edit-billing-information-address-email"

--- a/features/promotions.feature
+++ b/features/promotions.feature
@@ -1,4 +1,4 @@
-@javascript @promotions
+@javascript @promotions @orca_ignore
 Feature: Test various scenarios for promotions
 
   Scenario: As a guest

--- a/modules/acm/composer.json
+++ b/modules/acm/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "drupal/acm_cart",
+    "type": "drupal-module",
+    "description": "This module lays the foundation to use the Acquia Commerce Connector Service.",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "drupal/pcb": "~1.0",
+        "drupal/simple_oauth": "^3"
+    }
+}

--- a/modules/acm_cart/composer.json
+++ b/modules/acm_cart/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "drupal/acm_cart",
+    "type": "drupal-module",
+    "description": "This module provides cart functionality to the Acquia Commerce Connector Service.",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "drupal/address": "^1.4.0",
+        "drupal/key_value_field": "~1.0"
+    }
+}

--- a/modules/acm_checkout/composer.json
+++ b/modules/acm_checkout/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "drupal/acm_checkout",
+    "type": "drupal-module",
+    "description": "This module provides cart checkout functionality to the Acquia Commerce Connector Service.",
+    "license": "GPL-2.0-or-later"
+}

--- a/modules/acm_customer/composer.json
+++ b/modules/acm_customer/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "drupal/acm_customer",
+    "type": "drupal-module",
+    "description": "This module provides customer profile functionality to the Acquia Commerce Connector Service.",
+    "license": "GPL-2.0-or-later"
+}

--- a/modules/acm_exception/composer.json
+++ b/modules/acm_exception/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "drupal/acm_exception",
+    "type": "drupal-module",
+    "description": "Provides configurable error messaging for API exceptions.",
+    "license": "GPL-2.0-or-later"
+}

--- a/modules/acm_payment/composer.json
+++ b/modules/acm_payment/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "drupal/acm_payment",
+    "type": "drupal-module",
+    "description": "This module provides payment functionality to the Acquia Commerce Connector Service.",
+    "license": "GPL-2.0-or-later"
+}

--- a/modules/acm_product/composer.json
+++ b/modules/acm_product/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "drupal/acm_product",
+    "type": "drupal-module",
+    "description": "This module provides a product content type and views to use with the Acquia Commerce Connector Service.",
+    "license": "GPL-2.0-or-later"
+}

--- a/modules/acm_promotion/composer.json
+++ b/modules/acm_promotion/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "drupal/acm_promotion",
+    "type": "drupal-module",
+    "description": "This module provides Promotions functionality to the Acquia Commerce Connector Service.",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "drupal/field_group": "^3.0@beta"
+    }
+}

--- a/modules/acm_promotion/src/AcmPromotionsManager.php
+++ b/modules/acm_promotion/src/AcmPromotionsManager.php
@@ -7,7 +7,7 @@ use Drupal\acm_sku\Entity\SKU;
 use Drupal\acm_sku\Entity\SKUInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\acm\I18nHelper;
-use Drupal\Core\Database\Driver\mysql\Connection;
+use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Language\LanguageInterface;
@@ -73,7 +73,7 @@ class AcmPromotionsManager {
   /**
    * Database connection service.
    *
-   * @var \Drupal\Core\Database\Driver\mysql\Connection
+   * @var \Drupal\Core\Database\Connection
    */
   protected $connection;
 
@@ -101,7 +101,7 @@ class AcmPromotionsManager {
    *   Queue factory service.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   Config factory service.
-   * @param \Drupal\Core\Database\Driver\mysql\Connection $connection
+   * @param \Drupal\Core\Database\Connection $connection
    *   Database connection service.
    * @param \Drupal\acm\I18nHelper $i18n_helper
    *   I18nHelper object.

--- a/modules/acm_sku/composer.json
+++ b/modules/acm_sku/composer.json
@@ -1,0 +1,10 @@
+{
+    "name": "drupal/acm_sku",
+    "type": "drupal-module",
+    "description": "This module provides SKU functionality to the Acquia Commerce Connector Service.",
+    "license": "GPL-2.0-or-later",
+    "require": {
+        "drupal/inline_entity_form": "^1.0@rc",
+        "drupal/key_value_field": "~1.0"
+    }
+}

--- a/modules/acm_sku/composer.json
+++ b/modules/acm_sku/composer.json
@@ -6,5 +6,10 @@
     "require": {
         "drupal/inline_entity_form": "^1.0@rc",
         "drupal/key_value_field": "~1.0"
+    },
+    "autoload": {
+        "classmap": [
+            "tests/src/"
+        ]
     }
 }

--- a/modules/acm_sku_position/composer.json
+++ b/modules/acm_sku_position/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "drupal/acm_sku_position",
+    "type": "drupal-module",
+    "description": "This module provides functionality to store the sku (product) position.",
+    "license": "GPL-2.0-or-later"
+}

--- a/modules/acm_sku_stock/composer.json
+++ b/modules/acm_sku_stock/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "drupal/acm_sku_stock",
+    "type": "drupal-module",
+    "description": "This module adds stock management functionality to the Acquia Commerce Connector.",
+    "license": "GPL-2.0-or-later"
+}

--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,4 @@
+---
+drupal/acquia_commercemanager:
+  url: ../commerce-manager
+  version_dev: 1.x-dev


### PR DESCRIPTION
@malachy-mcconnell This PR replaces Commerce Manager's ad hoc Travis CI configuration with a standard ORCA implementation. You can see from the build results that there's an automated test failure in jobs two (2) and three (3). If your tests currently pass in your ad hoc setup, we'll need to identify what differs in order to determine the correct remediation. Aside from [the main features of ORCA and its total value proposition](https://github.com/acquia/orca#orca), the most salient differences between this (default) ORCA implementation and your current Travis CI setup are these:

* This doesn't run on multiple versions of PHP. Instead, it runs on the lowest Acquia-supported version (currently 7.1) and uses static analysis tools to scan for cross-version incompatibilities. (Much faster.)
* This tests against two versions of Drupal core--the current stable release and the current dev branch--as opposed to your current matrix. You can add any other versions you want to the build matrix with the [`ORCA_DRUPAL_CORE_VERSION`](https://github.com/acquia/orca/blob/v1.0.0-alpha6/docs/advanced-usage.md#ORCA_DRUPAL_CORE_VERSION) environment variable.

Please take a look at the changes and the build output and let me know what you think. I look forward to getting you running on ORCA! 😃 
