### PR TITLE
Removing deprecated method (+ some static issue) for acm_customer

### DIFF
--- a/modules/acm_customer/src/Commands/AcmCustomerDrushCommands.php
+++ b/modules/acm_customer/src/Commands/AcmCustomerDrushCommands.php
@@ -33,6 +33,7 @@ class AcmCustomerDrushCommands extends DrushCommands {
    */
   public function __construct(Connection $connection,
                               LoggerChannelFactoryInterface $logger_factory) {
+    parent::__construct();
     $this->connection = $connection;
     $this->setLogger($logger_factory->get('AcmCustomerDrushCommands'));
   }

--- a/modules/acm_customer/src/Controller/CustomerController.php
+++ b/modules/acm_customer/src/Controller/CustomerController.php
@@ -16,6 +16,8 @@ use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Form\FormState;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Url;
+use Drupal\acm_customer\Ajax\CustomerFormMessageCommand;
+use Drupal\acm\Response\NeedsRedirectException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -154,7 +156,7 @@ class CustomerController extends ControllerBase {
    * @param string $id
    *   The id route parameter.
    *
-   * @return Drupal\Core\Ajax\AjaxResponse
+   * @return \Drupal\Core\Ajax\AjaxResponse
    *   The form.
    */
   public function ajaxFormPage(Request $request, $action = NULL, $id = NULL) {

--- a/modules/acm_customer/src/CustomerPagesManager.php
+++ b/modules/acm_customer/src/CustomerPagesManager.php
@@ -4,6 +4,7 @@ namespace Drupal\acm_customer;
 
 use Drupal\Core\Plugin\DefaultPluginManager;
 use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Component\Plugin\Exception\PluginException;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 
 /**

--- a/modules/acm_customer/src/Plugin/CustomerForm/Orders.php
+++ b/modules/acm_customer/src/Plugin/CustomerForm/Orders.php
@@ -142,11 +142,11 @@ class Orders extends CustomerFormBase implements CustomerFormInterface {
 
     try {
       $cart->updateCart();
-      drupal_set_message($this->t('Your cart has been updated.'));
+      $this->messenger()->addStatus($this->t('Your cart has been updated.'));
       $form_state->setRedirect('acm_cart.cart');
     }
     catch (\Exception $e) {
-      drupal_set_message($this->t('Something went wrong and the order could not be added to your cart.'));
+      $this->messenger()->addError($this->t('Something went wrong and the order could not be added to your cart.'));
     }
   }
 

--- a/modules/acm_customer/src/Plugin/CustomerPages/CustomerPagesBase.php
+++ b/modules/acm_customer/src/Plugin/CustomerPages/CustomerPagesBase.php
@@ -260,7 +260,7 @@ abstract class CustomerPagesBase extends PluginBase implements CustomerPagesInte
    * {@inheritdoc}
    */
   public function calculateDependencies() {
-    $dependencies = parent::calculateDependencies();
+    $dependencies = [];
     // Merge-in the form dependencies.
     foreach ($this->getChildForms() as $child_form) {
       foreach ($child_form->calculateDependencies() as $dependency_type => $list) {

--- a/modules/acm_customer/tests/src/Unit/CustomerDeleteResourceTest.php
+++ b/modules/acm_customer/tests/src/Unit/CustomerDeleteResourceTest.php
@@ -24,7 +24,7 @@ class CustomerDeleteResourceTest extends UnitTestCase {
   /**
    * The customer delete resource.
    *
-   * @var \Drupal\acm_customer\Plugin\rest\resource|\PHPUnit_Framework_MockObject_MockObject
+   * @var \Drupal\acm_customer\Plugin\rest\resource\CustomerDeleteResource|\PHPUnit_Framework_MockObject_MockObject
    */
   protected $customerDeleteResource;
 


### PR DESCRIPTION
Apart from fixing depercated `drupal_set_message`, there were some issues analyzed by static analyzer like -
1. NeedsRedirectException, CustomerFormMessageCommand used in CustomerController but not defined.
2. PluginException used in CustomerPagesManager but not defined.
3. CustomerPagesBase calls `parent:: calculateDependencies()` but parent doesn't have this method.