### PR TITLE
D9 ready acm_cart module.

### DIFF
--- a/modules/acm_cart/acm_cart.services.yml
+++ b/modules/acm_cart/acm_cart.services.yml
@@ -1,7 +1,7 @@
 services:
   acm_cart.cart_storage:
     class: Drupal\acm_cart\CartStorage
-    arguments: ['@acm.session_storage', '@acm.api', '@event_dispatcher', '@logger.factory']
+    arguments: ['@acm.session_storage', '@acm.api', '@event_dispatcher', '@logger.factory', '@config.factory', '@acm.commerce_user_manager', '@current_user', '@request_stack']
   acm_cart.mini_cart:
     class: Drupal\acm_cart\MiniCartManager
     arguments: ['@acm_cart.cart_storage']

--- a/modules/acm_cart/src/Form/EmptyCartForm.php
+++ b/modules/acm_cart/src/Form/EmptyCartForm.php
@@ -127,7 +127,7 @@ class EmptyCartForm extends FormBase {
     $this->cartStorage->clearCart();
     $form_state->setRedirect($route);
 
-    drupal_set_message($this->t('Cart has been cleared.'));
+    $this->messenger()->addStatus($this->t('Cart has been cleared.'));
   }
 
   /**

--- a/modules/acm_cart/src/MiniCartManager.php
+++ b/modules/acm_cart/src/MiniCartManager.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\acm_cart;
 
+use Drupal\acm\I18nHelper;;
+
 /**
  * Class MiniCartManager.
  *
@@ -10,13 +12,31 @@ namespace Drupal\acm_cart;
 class MiniCartManager {
 
   /**
+   * Cart storage.
+   *
+   * @var \Drupal\acm_cart\CartStorageInterface
+   */
+  protected $cartStorage;
+
+  /**
+   * I18 helper.
+   *
+   * @var \Drupal\acm\I18nHelper
+   */
+  protected $i18Helper;
+
+  /**
    * MiniCartManager constructor.
    *
    * @param \Drupal\acm_cart\CartStorageInterface $cartStorage
    *   Cart storage service.
+   * @param \Drupal\acm\I18nHelper $i18_helper
+   *   I18 helper.
    */
-  public function __construct(CartStorageInterface $cartStorage) {
+  public function __construct(CartStorageInterface $cartStorage,
+                              I18nHelper $i18_helper) {
     $this->cartStorage = $cartStorage;
+    $this->i18Helper = $i18_helper;
   }
 
   /**
@@ -47,7 +67,7 @@ class MiniCartManager {
       }
 
       $total = [
-        '#markup' => \Drupal::service('acm.i18n_helper')->formatPrice($grand_total),
+        '#markup' => $this->i18Helper->formatPrice($grand_total),
       ];
 
       // Use the template to render the HTML.

--- a/modules/acm_cart/src/Plugin/Block/CartFormBlock.php
+++ b/modules/acm_cart/src/Plugin/Block/CartFormBlock.php
@@ -4,6 +4,9 @@ namespace Drupal\acm_cart\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 use Drupal\acm_cart\Form\CustomerCartForm;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a 'CartFormBlock' block.
@@ -13,7 +16,43 @@ use Drupal\acm_cart\Form\CustomerCartForm;
  *   admin_label = @Translation("Cart Form block"),
  * )
  */
-class CartFormBlock extends BlockBase {
+class CartFormBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * Form builder.
+   *
+   * @var \Drupal\Core\Form\FormBuilderInterface
+   */
+  protected $formBuilder;
+
+  /**
+   * CartFormBlock constructor.
+   *
+   * @param array $configuration
+   *   Plugin configuration.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   he plugin implementation definition.
+   * @param \Drupal\Core\Form\FormBuilderInterface $form_builder
+   *   Form builder.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, FormBuilderInterface $form_builder) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->formBuilder = $form_builder;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('form_builder')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -21,8 +60,7 @@ class CartFormBlock extends BlockBase {
   public function build() {
     $build = [];
 
-    $build['cart_form_block'] = \Drupal::formBuilder()
-      ->getForm(CustomerCartForm::class);
+    $build['cart_form_block'] = $this->formBuilder->getForm(CustomerCartForm::class);
 
     return $build;
   }

--- a/modules/acm_cart/tests/src/Unit/CartStorageTest.php
+++ b/modules/acm_cart/tests/src/Unit/CartStorageTest.php
@@ -69,8 +69,8 @@ class CartStorageTest extends UnitTestCase {
   protected function setUp() {
     parent::setUp();
 
-    $this->session = $this->getMock('Drupal\acm\SessionStoreInterface');
-    $this->logger = $this->getMock('Drupal\Core\Logger\LoggerChannelFactoryInterface');
+    $this->session = $this->createMock('Drupal\acm\SessionStoreInterface');
+    $this->logger = $this->createMock('Drupal\Core\Logger\LoggerChannelFactoryInterface');
     $this->eventDispatcher = new EventDispatcher();
     $this->apiWrapper = new MockAPIWrapper();
 
@@ -91,7 +91,9 @@ class CartStorageTest extends UnitTestCase {
       return $m->getName();
     }, (new \ReflectionClass($interface))->getMethods());
     $methods[] = 'getCartItemsCount';
-    $mock_cart = $this->getMock($interface, $methods);
+    $mock_cart = $this->getMockBuilder($interface)
+      ->setMethods($methods)
+      ->getMock();
     $mock_cart->cart = $cart;
     $mock_cart->expects($this->any())
       ->method('id')
@@ -185,7 +187,7 @@ class CartStorageTest extends UnitTestCase {
    * @covers ::loadCart
    */
   public function testLoadCartWithCartInSession() {
-    $session = $this->getMock('Drupal\acm\SessionStoreInterface');
+    $session = $this->createMock('Drupal\acm\SessionStoreInterface');
 
     $session->expects($this->at(0))
       ->method('get')
@@ -208,7 +210,7 @@ class CartStorageTest extends UnitTestCase {
    * @covers ::loadCart
    */
   public function testLoadCartNoCartInSession() {
-    $session = $this->getMock('Drupal\acm\SessionStoreInterface');
+    $session = $this->createMock('Drupal\acm\SessionStoreInterface');
 
     $session->expects($this->exactly(1))
       ->method('get')
@@ -238,7 +240,7 @@ class CartStorageTest extends UnitTestCase {
    * @covers ::updateCart
    */
   public function testUpdateCart() {
-    $session = $this->getMock('Drupal\acm\SessionStoreInterface');
+    $session = $this->createMock('Drupal\acm\SessionStoreInterface');
 
     $session->expects($this->exactly(1))
       ->method('get')


### PR DESCRIPTION
the issue yet not handled in this PR -
```
------ ----------------------------------------------------------------
  Line   src/Cart.php
 ------ ----------------------------------------------------------------
  177    Access to an undefined property Drupal\acm_cart\Cart::$logger.
 ------ ----------------------------------------------------------------

 ------ ------------------------------------------------------------------------------
  Line   src/CartStorage.php
 ------ ------------------------------------------------------------------------------
  460    \Drupal calls should be avoided in classes, use dependency injection instead
  464    \Drupal calls should be avoided in classes, use dependency injection instead
  467    \Drupal calls should be avoided in classes, use dependency injection instead
  486    \Drupal calls should be avoided in classes, use dependency injection instead
  506    \Drupal calls should be avoided in classes, use dependency injection instead
  507    \Drupal calls should be avoided in classes, use dependency injection instead
  526    \Drupal calls should be avoided in classes, use dependency injection instead
  527    \Drupal calls should be avoided in classes, use dependency injection instead
 ------ ------------------------------------------------------------------------------
```

1. For the `CartStorage.php` dependencies, I am not sure if should fix or not as this will be BC break
if someone has changed/override the service.
2. As `Cart::$logger` is not a service, so not sure how we handle this. But this definitely looks bug.