### PR TITLE
Fix the notice/warning when cart object not available.

### DIFF
--- a/modules/acm/src/Connector/APIWrapper.php
+++ b/modules/acm/src/Connector/APIWrapper.php
@@ -175,7 +175,7 @@ class APIWrapper implements APIWrapperInterface {
     // But for robustness we go back to the SKU plugin and ask
     // it to return a name as a string only.
     $originalItemsNames = [];
-    $items = $cart->items;
+    $items = $cart->items ?? NULL;
     if ($items) {
       foreach ($items as $key => &$item) {
         $cart->items[$key]['qty'] = (int) $item['qty'];


### PR DESCRIPTION
Use of `$cart->items` throwing notice `Trying to get property of non-object` as cart object is not available.

**Steps to reproduce** -
1. User has cartid cookie but not the cart storage session.

**For the flow** -
1. CartMiniBlock calls CartStorage::getCart()
2. Which further calls CartStorage::updateCart() with `FALSE`.
3. In CartStorage::updateCart(), `$cartObject = (object) $this->apiWrapper->updateCart($cart_id, $update);` is called where $update is null as cart session object not available.

