### PR TITLE
WIP: Deprecate SKUFieldsManager class.

### DIFF
--- a/modules/acm_sku/src/SKUFieldsManager.php
+++ b/modules/acm_sku/src/SKUFieldsManager.php
@@ -11,7 +11,8 @@ use Psr\Log\LoggerInterface;
 /**
  * Class SKUFieldsManager.
  *
- * @package Drupal\acm_sku
+ * @deprecated This class will be removed in the 8.x-2.0 release. You should use
+ * update hooks instead of it.
  */
 class SKUFieldsManager {
 


### PR DESCRIPTION
```
a:4:{s:11:"deprecation";s:311:"EntityDefinitionUpdateManagerInterface::applyUpdates() is deprecated in 8.7.0 and will be removed before Drupal 9.0.0. Use \Drupal\Core\Entity\EntityDefinitionUpdateManagerInterface::getChangeList() and execute each entity type and field storage update manually instead. See https://www.drupal.org/node/3034742.";s:5:"class";s:51:"Drupal\Tests\acq_sku\Functional\CategoryManagerTest";s:6:"method";s:16:"testSyncCategory";s:15:"triggering_file";s:106:"/home/travis/build/acquia/orca-build/docroot/core/lib/Drupal/Core/Entity/EntityDefinitionUpdateManager.php";}
```